### PR TITLE
Fix Index Bug

### DIFF
--- a/ezclimate/bau.py
+++ b/ezclimate/bau.py
@@ -127,7 +127,7 @@ class DLWBusinessAsUsual(BusinessAsUsual):
 
         for n in range(1, num_periods):
             self.emission_by_decisions[n] = self.emission_by_time(tree.decision_times[n])
-            self.emission_per_period[n] = period_len[n] * (self.emission_by_decisions[n-1:n].mean())
+            self.emission_per_period[n] = period_len[n-1] * (self.emission_by_decisions[n-1:n+1].mean())
 
         #the total increase in ghg level of 600 (from 400 to 1000) in the bau path is allocated over time
         self.emission_to_ghg = (self.ghg_end - self.ghg_start) * self.emission_per_period / self.emission_per_period.sum()


### PR DESCRIPTION
Fix bug spotted by Alexey Rubtsov. Index `[n-1:n]` only accesses the `n-1`-th element. According to the function comment, `[n-1,n+1]` is meant here. Also `period_len[n-1]` corresponds to this time range, instead of `period_len[n]`. This change is untested due to lack of testing in this repo. Please verify before approval.